### PR TITLE
fix: Deployment With Constructor Args

### DIFF
--- a/src/HuffDeployer.sol
+++ b/src/HuffDeployer.sol
@@ -5,10 +5,10 @@ library HuffDeployer {
     /// @notice Initializes cheat codes in order to use ffi to compile Huff contracts
     VM constant vm = VM(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
 
-    ///@notice Compiles a Huff contract and returns the address that the contract was deployeod to
-    ///@notice If deployment fails, an error will be thrown
-    ///@param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
-    ///@return deployedAddress - The address that the contract was deployed to
+    /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
+    /// @notice If deployment fails, an error will be thrown
+    /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
+    /// @return deployedAddress - The address that the contract was deployed to
     function deploy(string memory fileName) internal returns (address) {
         ///@notice create a list of strings with the commands necessary to compile Huff contracts
         string[] memory cmds = new string[](3);
@@ -23,6 +23,38 @@ library HuffDeployer {
         address deployedAddress;
         assembly {
             deployedAddress := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        /// @notice check that the deployment was successful
+        require(
+            deployedAddress != address(0),
+            "HuffDeployer could not deploy contract"
+        );
+
+        /// @notice return the address that the contract was deployed to
+        return deployedAddress;
+    }
+
+    /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
+    /// @notice If deployment fails, an error will be thrown
+    /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
+    /// @param args - Constructor Args to append to the bytecode
+    /// @return deployedAddress - The address that the contract was deployed to
+    function deploy_with_args(string memory fileName, bytes memory args) internal returns (address) {
+        /// Create a list of strings with the commands necessary to compile Huff contracts
+        string[] memory cmds = new string[](3);
+        cmds[0] = "huffc";
+        cmds[1] = string(string.concat("src/", fileName, ".huff"));
+        cmds[2] = "-b";
+
+        /// @notice compile the Huff contract and return the bytecode
+        bytes memory bytecode = vm.ffi(cmds);
+        bytes memory concatenated = bytes.concat(bytecode, args);
+
+        /// @notice deploy the bytecode with the create instruction
+        address deployedAddress;
+        assembly {
+            deployedAddress := create(0, add(concatenated, 0x20), mload(concatenated))
         }
 
         /// @notice check that the deployment was successful

--- a/src/test/HuffDeployer.t.sol
+++ b/src/test/HuffDeployer.t.sol
@@ -10,12 +10,35 @@ interface Number {
     function getNumber() external returns (uint256);
 }
 
+interface Constructor {
+    function getArgOne() external returns (address);
+    function getArgTwo() external returns (uint256);
+}
+
 contract HuffDeployerTest is Test {
     Number number;
+    Constructor structor;
 
     function setUp() public {
-        ///@notice deploy a new instance of ISimplestore by passing in the address of the deployed Huff contract
         number = Number(HuffDeployer.deploy("test/contracts/Number"));
+
+        // Showcase alignment of address
+        bytes memory first_arg = abi.encodePacked(address(0x420));
+        // assertEq(bytes(hex"0000000000000000000000004200000000000000000000000000000000000000"), first_arg);
+
+        // Create Constructor
+        structor = Constructor(HuffDeployer.deploy_with_args(
+            "test/contracts/Constructor",
+            bytes.concat(first_arg, abi.encodePacked(uint256(0x420)))
+        ));
+    }
+
+    function testArgOne() public {
+        assertEq(address(0x420), structor.getArgOne());
+    }
+
+    function testArgTwo() public {
+        assertEq(uint256(0x420), structor.getArgTwo());
     }
 
     function testBytecode() public {

--- a/src/test/contracts/Constructor.huff
+++ b/src/test/contracts/Constructor.huff
@@ -1,0 +1,61 @@
+/* Interface */
+#define function getArgOne() view returns (address)
+#define function getArgTwo() view returns (uint256)
+
+/* Storage Slots */
+#define constant CONSTRUCTOR_ARG_ONE = FREE_STORAGE_POINTER()
+#define constant CONSTRUCTOR_ARG_TWO = FREE_STORAGE_POINTER()
+
+/* Constructor */
+#define macro CONSTRUCTOR() = takes(0) returns (0) {
+  // -------------            --------------------------
+  // | OPERATION |            | STACK (POST-OPERATION) |
+  // -------------            --------------------------
+
+  // Copy the first argument into memory
+  0x20                        // [size] - byte size to copy
+  0x40 codesize sub           // [offset, size] - offset in the code to copy from
+  0x00                        // [mem, offset, size] - offset in memory to copy to
+  codecopy                    // []
+
+  // Store the first argument in storage
+  0x00 mload                  // [arg]
+  [CONSTRUCTOR_ARG_ONE]       // [CONSTRUCTOR_ARG_ONE, arg]
+  sstore                      // []
+
+  // Copy the second argument into memory
+  0x20                        // [size] - byte size to copy
+  0x20 codesize sub           // [offset, size] - offset in the code to copy from
+  0x00                        // [mem, offset, size] - offset in memory to copy to
+  codecopy                    // []
+
+  // Store the second argument in storage
+  0x00 mload                  // [arg]
+  [CONSTRUCTOR_ARG_TWO]       // [CONSTRUCTOR_ARG_TWO, arg]
+  sstore                      // []
+}
+
+/* First Argument Accessor */
+#define macro GET_ARG_ONE() = takes (0) returns (0) {
+    [CONSTRUCTOR_ARG_ONE] sload
+    0x00 mstore
+    0x20 0x00 return
+}
+
+#define macro GET_ARG_TWO() = takes (0) returns (0) {
+    [CONSTRUCTOR_ARG_TWO] sload
+    0x00 mstore
+    0x20 0x00 return
+}
+
+#define macro MAIN() = takes (0) returns (0) {
+    0x00 calldataload 0xE0 shr
+    dup1 0xbb01e52d eq arg_one jumpi
+    dup1 0x98e45be4 eq arg_two jumpi
+
+    arg_one:
+        GET_ARG_ONE()
+    arg_two:
+        GET_ARG_TWO()
+
+}


### PR DESCRIPTION
Adds a `deploy_with_args` method to the HuffDeployer Library.