### PR TITLE
feat: Add support for const overrides

### DIFF
--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -5,120 +5,157 @@ import {Vm} from "forge-std/Vm.sol";
 import {strings} from "stringutils/strings.sol";
 
 contract HuffConfig {
-  using strings for *;
+    using strings for *;
 
-  /// @notice Initializes cheat codes in order to use ffi to compile Huff contracts
-  Vm public constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+    /// @notice Initializes cheat codes in order to use ffi to compile Huff contracts
+    Vm public constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
 
-  /// @notice additional code to append to the source file
-  string public code;
-
-  /// @notice arguments to append to the bytecode
-  bytes public args;
-
-  /// @notice sets the code to be appended to the source file
-  function with_code(string memory acode) public returns (HuffConfig) {
-    code = acode;
-    return this;
-  }
-
-  /// @notice sets the arguments to be appended to the bytecode
-  function with_args(bytes memory aargs) public returns (HuffConfig) {
-    args = aargs;
-    return this;
-  }
-
-  /// @notice Checks for huffc binary conflicts
-  function binary_check() public {
-    string[] memory bincheck = new string[](1);
-    bincheck[0] = "./lib/foundry-huff/scripts/binary_check.sh";
-    bytes memory retData = vm.ffi(bincheck);
-    bytes8 first_bytes = retData[0];
-    bool decoded = first_bytes == bytes8(hex"01");
-    require(decoded, "Invalid huffc binary. Run `curl -L get.huff.sh | bash` and `huffup` to fix.");
-  }
-
-  function bytesToString(bytes32 x) internal pure returns (string memory) {
-    string memory result;
-    for (uint j = 0; j < x.length; j++) {
-      result = string.concat(result, string(abi.encodePacked(uint8(x[j]) % 26 + 97)));
-    }
-    return result;
-  }
-
-  /// @notice Deploy the Contract
-  function deploy(string memory file) public returns (address) {
-    binary_check();
-
-    // Split the file into it's parts
-    strings.slice memory s = file.toSlice();
-    strings.slice memory delim = "/".toSlice();
-    string[] memory parts = new string[](s.count(delim) + 1);
-    for (uint i = 0; i < parts.length; i++) {
-      parts[i] = s.split(delim).toString();
+    /// @notice Struct that represents a constant to be passed to the `-c` flag
+    struct Constant {
+        string key;
+        string value;
     }
 
-    // Get the system time with our script
-    string[] memory time = new string[](1);
-    time[0] = "./lib/foundry-huff/scripts/rand_bytes.sh";
-    bytes memory retData = vm.ffi(time);
-    string memory rand_bytes = bytesToString(keccak256(abi.encode(bytes32(retData))));
+    /// @notice additional code to append to the source file
+    string public code;
 
-    // Re-concatenate the file with a "__TEMP__" prefix
-    string memory tempFile = parts[0];
-    if (parts.length <= 1) {
-      tempFile = string.concat("__TEMP__", rand_bytes, tempFile);
-    } else {
-      for (uint i = 1; i < parts.length - 1; i++) {
-        tempFile = string.concat(tempFile, "/", parts[i]);
-      }
-      tempFile = string.concat(tempFile, "/", "__TEMP__", rand_bytes, parts[parts.length - 1]);
+    /// @notice arguments to append to the bytecode
+    bytes public args;
+
+    /// @notice constant overrides for the current compilation environment
+    Constant[] public const_overrides;
+
+    /// @notice sets the code to be appended to the source file
+    function with_code(string memory acode) public returns (HuffConfig) {
+        code = acode;
+        return this;
     }
 
-    // Paste the code in a new temp file
-    string[] memory create_cmds = new string[](3);
-    // TODO: create_cmds[0] = "$(find . -name \"file_writer.sh\")";
-    create_cmds[0] = "./lib/foundry-huff/scripts/file_writer.sh";
-    create_cmds[1] = string.concat("src/", tempFile, ".huff");
-    create_cmds[2] = string.concat(code, "\n");
-    vm.ffi(create_cmds);
-
-    // Append the real code to the temp file
-    string[] memory append_cmds = new string[](3);
-    append_cmds[0] = "./lib/foundry-huff/scripts/read_and_append.sh";
-    append_cmds[1] = string.concat("src/", tempFile, ".huff");
-    append_cmds[2] = string.concat("src/", file, ".huff");
-    vm.ffi(append_cmds);
-
-    /// Create a list of strings with the commands necessary to compile Huff contracts
-    string[] memory cmds = new string[](3);
-    cmds[0] = "huffc";
-    cmds[1] = string(string.concat("src/", tempFile, ".huff"));
-    cmds[2] = "-b";
-
-    /// @notice compile the Huff contract and return the bytecode
-    bytes memory bytecode = vm.ffi(cmds);
-    bytes memory concatenated = bytes.concat(bytecode, args);
-
-    // Clean up temp files
-    string[] memory cleanup = new string[](2);
-    cleanup[0] = "rm";
-    cleanup[1] = string.concat("src/", tempFile, ".huff");
-    vm.ffi(cleanup);
-
-    /// @notice deploy the bytecode with the create instruction
-    address deployedAddress;
-    assembly {
-      deployedAddress := create(0, add(concatenated, 0x20), mload(concatenated))
+    /// @notice sets the arguments to be appended to the bytecode
+    function with_args(bytes memory aargs) public returns (HuffConfig) {
+        args = aargs;
+        return this;
     }
 
-    /// @notice check that the deployment was successful
-    require(
-      deployedAddress != address(0),
-      "HuffDeployer could not deploy contract"
-    );
+    /// @notice sets a constant to a bytes32 value in the current compilation environment
+    /// TODO: Create other functions to accept `bytes32`, `address`, `uint`, etc.
+    function with_constant(
+        string memory key,
+        string memory value
+    ) public returns (HuffConfig) {
+        const_overrides.push(Constant(key, value));
+        return this;
+    }
 
-    /// @notice return the address that the contract was deployed to
-    return deployedAddress;
-  }
+    /// @notice Checks for huffc binary conflicts
+    function binary_check() public {
+        string[] memory bincheck = new string[](1);
+        bincheck[0] = "./lib/foundry-huff/scripts/binary_check.sh";
+        bytes memory retData = vm.ffi(bincheck);
+        bytes8 first_bytes = retData[0];
+        bool decoded = first_bytes == bytes8(hex"01");
+        require(
+            decoded,
+            "Invalid huffc binary. Run `curl -L get.huff.sh | bash` and `huffup` to fix."
+        );
+    }
+
+    function bytesToString(bytes32 x) internal pure returns (string memory) {
+        string memory result;
+        for (uint256 j = 0; j < x.length; j++) {
+            result = string.concat(
+                result, string(abi.encodePacked(uint8(x[j]) % 26 + 97))
+            );
+        }
+        return result;
+    }
+
+    /// @notice Deploy the Contract
+    function deploy(string memory file) public returns (address) {
+        binary_check();
+
+        // Split the file into it's parts
+        strings.slice memory s = file.toSlice();
+        strings.slice memory delim = "/".toSlice();
+        string[] memory parts = new string[](s.count(delim) + 1);
+        for (uint256 i = 0; i < parts.length; i++) {
+            parts[i] = s.split(delim).toString();
+        }
+
+        // Get the system time with our script
+        string[] memory time = new string[](1);
+        time[0] = "./lib/foundry-huff/scripts/rand_bytes.sh";
+        bytes memory retData = vm.ffi(time);
+        string memory rand_bytes =
+            bytesToString(keccak256(abi.encode(bytes32(retData))));
+
+        // Re-concatenate the file with a "__TEMP__" prefix
+        string memory tempFile = parts[0];
+        if (parts.length <= 1) {
+            tempFile = string.concat("__TEMP__", rand_bytes, tempFile);
+        } else {
+            for (uint256 i = 1; i < parts.length - 1; i++) {
+                tempFile = string.concat(tempFile, "/", parts[i]);
+            }
+            tempFile = string.concat(
+                tempFile, "/", "__TEMP__", rand_bytes, parts[parts.length - 1]
+            );
+        }
+
+        // Paste the code in a new temp file
+        string[] memory create_cmds = new string[](3);
+        // TODO: create_cmds[0] = "$(find . -name \"file_writer.sh\")";
+        create_cmds[0] = "./lib/foundry-huff/scripts/file_writer.sh";
+        create_cmds[1] = string.concat("src/", tempFile, ".huff");
+        create_cmds[2] = string.concat(code, "\n");
+        vm.ffi(create_cmds);
+
+        // Append the real code to the temp file
+        string[] memory append_cmds = new string[](3);
+        append_cmds[0] = "./lib/foundry-huff/scripts/read_and_append.sh";
+        append_cmds[1] = string.concat("src/", tempFile, ".huff");
+        append_cmds[2] = string.concat("src/", file, ".huff");
+        vm.ffi(append_cmds);
+
+        /// Create a list of strings with the commands necessary to compile Huff contracts
+        string[] memory cmds = new string[](3);
+        if (const_overrides.length > 0) {
+            cmds = new string[](4 + const_overrides.length);
+            cmds[3] = "-c";
+
+            Constant memory cur_const;
+            for (uint256 i; i < const_overrides.length; i++) {
+                cur_const = const_overrides[i];
+                cmds[4 + i] = string.concat(cur_const.key, "=", cur_const.value);
+            }
+        }
+
+        cmds[0] = "huffc";
+        cmds[1] = string(string.concat("src/", tempFile, ".huff"));
+        cmds[2] = "-b";
+
+        /// @notice compile the Huff contract and return the bytecode
+        bytes memory bytecode = vm.ffi(cmds);
+        bytes memory concatenated = bytes.concat(bytecode, args);
+
+        // Clean up temp files
+        string[] memory cleanup = new string[](2);
+        cleanup[0] = "rm";
+        cleanup[1] = string.concat("src/", tempFile, ".huff");
+        vm.ffi(cleanup);
+
+        /// @notice deploy the bytecode with the create instruction
+        address deployedAddress;
+        assembly {
+          deployedAddress := create(0, add(concatenated, 0x20), mload(concatenated))
+        }
+
+        /// @notice check that the deployment was successful
+        require(
+            deployedAddress != address(0), "HuffDeployer could not deploy contract"
+        );
+
+        /// @notice return the address that the contract was deployed to
+        return deployedAddress;
+    }
 }

--- a/src/HuffDeployer.sol
+++ b/src/HuffDeployer.sol
@@ -21,7 +21,10 @@ library HuffDeployer {
     /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
     /// @param args - Constructor Args to append to the bytecode
     /// @return The address that the contract was deployed to
-    function deploy_with_args(string memory fileName, bytes memory args) internal returns (address) {
+    function deploy_with_args(
+        string memory fileName,
+        bytes memory args
+    ) internal returns (address) {
         return config().with_args(args).deploy(fileName);
     }
 
@@ -29,7 +32,10 @@ library HuffDeployer {
     /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
     /// @param code - Code to append to the file source code (e.g. a constructor macro to make the contract instantiable)
     /// @return The address that the contract was deployed to
-    function deploy_with_code(string memory fileName, string memory code) internal returns (address) {
+    function deploy_with_code(
+        string memory fileName, 
+        string memory code
+    ) internal returns (address) {
         return config().with_code(code).deploy(fileName);
     }
 
@@ -38,7 +44,11 @@ library HuffDeployer {
     /// @param code - Code to append to the file source code (e.g. a constructor macro to make the contract instantiable)
     /// @param args - Constructor Args to append to the bytecode
     /// @return The address that the contract was deployed to
-    function deploy_with_code_args(string memory fileName, string memory code, bytes memory args) internal returns (address) {
+    function deploy_with_code_args(
+        string memory fileName,
+        string memory code,
+        bytes memory args
+    ) internal returns (address) {
         return config().with_code(code).with_args(args).deploy(fileName);
     }
 }

--- a/src/depreciated/StatefulDeployer.sol
+++ b/src/depreciated/StatefulDeployer.sol
@@ -6,68 +6,70 @@ import {strings} from "stringutils/strings.sol";
 import {HuffDeployer} from "../HuffDeployer.sol";
 
 contract StatefulDeployer {
-  using strings for *;
+    using strings for *;
 
-  /// @notice Initializes cheat codes in order to use ffi to compile Huff contracts
-  Vm public constant vm = Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
+    /// @notice Initializes cheat codes in order to use ffi to compile Huff contracts
+    Vm public constant vm =
+        Vm(address(bytes20(uint160(uint256(keccak256("hevm cheat code"))))));
 
-  /// @notice additional code to append to the source file
-  string public code;
+    /// @notice additional code to append to the source file
+    string public code;
 
-  /// @notice arguments to append to the bytecode
-  bytes public args;
+    /// @notice arguments to append to the bytecode
+    bytes public args;
 
-  /// @notice sets the code to be appended to the source file
-  function setCode(string memory acode) public {
-    code = acode;
-  }
-
-  /// @notice sets the arguments to be appended to the bytecode
-  function setArgs(bytes memory aargs) public {
-    args = aargs;
-  }
-
-  /// @notice Deployment wrapper
-  function deploy(string memory file) public returns (address) {
-    // Split the file into it's parts
-    strings.slice memory s = file.toSlice();
-    strings.slice memory delim = "/".toSlice();
-    string[] memory parts = new string[](s.count(delim) + 1);
-    for (uint i = 0; i < parts.length; i++) {
-      parts[i] = s.split(delim).toString();
+    /// @notice sets the code to be appended to the source file
+    function setCode(string memory acode) public {
+        code = acode;
     }
 
-    // Re-concatenate the file with a "__TEMP__" prefix
-    string memory tempFile = parts[0];
-    for (uint i = 1; i < parts.length - 1; i++) {
-      tempFile = string.concat(tempFile, "/", parts[i]);
+    /// @notice sets the arguments to be appended to the bytecode
+    function setArgs(bytes memory aargs) public {
+        args = aargs;
     }
-    tempFile = string.concat(tempFile, "/", "__TEMP__", parts[parts.length - 1]);
 
-    // Paste the code in a new temp file
-    string[] memory create_cmds = new string[](3);
-    create_cmds[0] = "./scripts/file_writer.sh";
-    create_cmds[1] = string.concat("src/", tempFile, ".huff");
-    create_cmds[2] = string.concat(code, "\n");
-    vm.ffi(create_cmds);
+    /// @notice Deployment wrapper
+    function deploy(string memory file) public returns (address) {
+        // Split the file into it's parts
+        strings.slice memory s = file.toSlice();
+        strings.slice memory delim = "/".toSlice();
+        string[] memory parts = new string[](s.count(delim) + 1);
+        for (uint256 i = 0; i < parts.length; i++) {
+            parts[i] = s.split(delim).toString();
+        }
 
-    // Append the real code to the temp file
-    string[] memory append_cmds = new string[](3);
-    append_cmds[0] = "./scripts/read_and_append.sh";
-    append_cmds[1] = string.concat("src/", tempFile, ".huff");
-    append_cmds[2] = string.concat("src/", file, ".huff");
-    vm.ffi(append_cmds);
+        // Re-concatenate the file with a "__TEMP__" prefix
+        string memory tempFile = parts[0];
+        for (uint256 i = 1; i < parts.length - 1; i++) {
+            tempFile = string.concat(tempFile, "/", parts[i]);
+        }
+        tempFile =
+            string.concat(tempFile, "/", "__TEMP__", parts[parts.length - 1]);
 
-    // Deploy with args the temp file
-    address deployed = HuffDeployer.deploy_with_args(tempFile, args);
+        // Paste the code in a new temp file
+        string[] memory create_cmds = new string[](3);
+        create_cmds[0] = "./scripts/file_writer.sh";
+        create_cmds[1] = string.concat("src/", tempFile, ".huff");
+        create_cmds[2] = string.concat(code, "\n");
+        vm.ffi(create_cmds);
 
-    // Clean up temp files
-    string[] memory cleanup = new string[](2);
-    cleanup[0] = "rm";
-    cleanup[1] = string.concat("src/", tempFile, ".huff");
-    vm.ffi(cleanup);
+        // Append the real code to the temp file
+        string[] memory append_cmds = new string[](3);
+        append_cmds[0] = "./scripts/read_and_append.sh";
+        append_cmds[1] = string.concat("src/", tempFile, ".huff");
+        append_cmds[2] = string.concat("src/", file, ".huff");
+        vm.ffi(append_cmds);
 
-    // Return the deployed address
-    return deployed;
-  }
+        // Deploy with args the temp file
+        address deployed = HuffDeployer.deploy_with_args(tempFile, args);
+
+        // Clean up temp files
+        string[] memory cleanup = new string[](2);
+        cleanup[0] = "rm";
+        cleanup[1] = string.concat("src/", tempFile, ".huff");
+        vm.ffi(cleanup);
+
+        // Return the deployed address
+        return deployed;
+    }
 }

--- a/src/depreciated/StatefulDeployer.t.sol
+++ b/src/depreciated/StatefulDeployer.t.sol
@@ -8,50 +8,52 @@ import {IConstructor} from "../test/interfaces/IConstructor.sol";
 import {StatefulDeployer} from "./StatefulDeployer.sol";
 
 contract StatefulDeployerTest is Test {
-  StatefulDeployer public deployer;
-  IConstructor public construct;
+    StatefulDeployer public deployer;
+    IConstructor public construct;
 
-  function setUp() public {
-    deployer = new StatefulDeployer();
-  }
+    function setUp() public {
+        deployer = new StatefulDeployer();
+    }
 
-  function testSetArgs(bytes memory some) public {
-    deployer.setArgs(some);
-    assertEq(deployer.args(), some);
-  }
+    function testSetArgs(bytes memory some) public {
+        deployer.setArgs(some);
+        assertEq(deployer.args(), some);
+    }
 
-  function testSetCode(string memory code) public {
-    deployer.setCode(code);
-    assertEq(deployer.code(), code);
-  }
+    function testSetCode(string memory code) public {
+        deployer.setCode(code);
+        assertEq(deployer.code(), code);
+    }
 
-  function testDeployWithArgsAndCode() public {
-    deployer.setArgs(bytes.concat(abi.encode(uint256(0x420)), abi.encode(uint256(0x420))));
-    deployer.setCode(""
-      "#define macro CONSTRUCTOR() = takes(0) returns (0) { \n"
-      "    // Copy the first argument into memory \n"
-      "    0x20                        // [size] - byte size to copy \n"
-      "    0x40 codesize sub           // [offset, size] - offset in the code to copy from \n"
-      "    0x00                        // [mem, offset, size] - offset in memory to copy to \n"
-      "    codecopy                    // [] \n"
-      "    // Store the first argument in storage \n"
-      "    0x00 mload                  // [arg] \n"
-      "    [CONSTRUCTOR_ARG_ONE]       // [CONSTRUCTOR_ARG_ONE, arg] \n"
-      "    sstore                      // [] \n"
-      "    // Copy the second argument into memory \n"
-      "    0x20                        // [size] - byte size to copy \n"
-      "    0x20 codesize sub           // [offset, size] - offset in the code to copy from \n"
-      "    0x00                        // [mem, offset, size] - offset in memory to copy to \n"
-      "    codecopy                    // [] \n"
-      "    // Store the second argument in storage \n"
-      "    0x00 mload                  // [arg] \n"
-      "    [CONSTRUCTOR_ARG_TWO]       // [CONSTRUCTOR_ARG_TWO, arg] \n"
-      "    sstore                      // [] \n"
-      "}"
-    );
+    function testDeployWithArgsAndCode() public {
+        deployer.setArgs(
+            bytes.concat(abi.encode(uint256(0x420)), abi.encode(uint256(0x420)))
+        );
+        deployer.setCode(
+            "" "#define macro CONSTRUCTOR() = takes(0) returns (0) { \n"
+            "    // Copy the first argument into memory \n"
+            "    0x20                        // [size] - byte size to copy \n"
+            "    0x40 codesize sub           // [offset, size] - offset in the code to copy from \n"
+            "    0x00                        // [mem, offset, size] - offset in memory to copy to \n"
+            "    codecopy                    // [] \n"
+            "    // Store the first argument in storage \n"
+            "    0x00 mload                  // [arg] \n"
+            "    [CONSTRUCTOR_ARG_ONE]       // [CONSTRUCTOR_ARG_ONE, arg] \n"
+            "    sstore                      // [] \n"
+            "    // Copy the second argument into memory \n"
+            "    0x20                        // [size] - byte size to copy \n"
+            "    0x20 codesize sub           // [offset, size] - offset in the code to copy from \n"
+            "    0x00                        // [mem, offset, size] - offset in memory to copy to \n"
+            "    codecopy                    // [] \n"
+            "    // Store the second argument in storage \n"
+            "    0x00 mload                  // [arg] \n"
+            "    [CONSTRUCTOR_ARG_TWO]       // [CONSTRUCTOR_ARG_TWO, arg] \n"
+            "    sstore                      // [] \n" "}"
+        );
 
-    construct = IConstructor(deployer.deploy("test/contracts/NoConstructor"));
-    assertEq(address(0x420), construct.getArgOne());
-    assertEq(uint256(0x420), construct.getArgTwo());
-  }
+        construct =
+            IConstructor(deployer.deploy("test/contracts/NoConstructor"));
+        assertEq(address(0x420), construct.getArgOne());
+        assertEq(uint256(0x420), construct.getArgTwo());
+    }
 }

--- a/src/test/HuffConfig.t.sol
+++ b/src/test/HuffConfig.t.sol
@@ -8,21 +8,30 @@ import {IConstructor} from "./interfaces/IConstructor.sol";
 import {HuffConfig} from "../HuffConfig.sol";
 
 contract HuffConfigTest is Test {
-  HuffConfig public config;
-  INumber public number;
+    HuffConfig public config;
+    INumber public number;
 
-  function setUp() public {
-    config = new HuffConfig();
-  }
+    function setUp() public {
+        config = new HuffConfig();
+    }
 
-  function testWithArgs(bytes memory some) public {
-    config.with_args(some);
-    assertEq(config.args(), some);
-  }
+    function testWithArgs(bytes memory some) public {
+        config.with_args(some);
+        assertEq(config.args(), some);
+    }
 
-  function testWithCode(string memory code) public {
-    config.with_code(code);
-    assertEq(config.code(), code);
-  }
+    function testWithCode(string memory code) public {
+        config.with_code(code);
+        assertEq(config.code(), code);
+    }
 
+    function testWithConstantOverrides(
+        string memory key,
+        string memory value
+    ) public {
+        config.with_constant(key, value);
+        (string memory k, string memory v) = config.const_overrides(0);
+        assertEq(key, k);
+        assertEq(value, v);
+    }
 }

--- a/src/test/HuffDeployer.t.sol
+++ b/src/test/HuffDeployer.t.sol
@@ -85,16 +85,33 @@ contract HuffDeployerTest is Test {
     }
 
     function testConstantOverride() public {
+        // Test address constant
+        address a = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
         address deployed = HuffDeployer.config()
-            .with_constant("a", "0xa57b")
+            .with_addr_constant("a", a)
             .with_constant("b", "0x420")
             .deploy("test/contracts/ConstOverride");
-        assertEq(getCode(deployed), hex"61a57b610420");
+        assertEq(getCode(deployed), hex"73DeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF610420");
 
+        // Test uint constant
         address deployed_2 = HuffDeployer.config()
+            .with_uint_constant("a", 32)
             .with_constant("b", "0x420")
             .deploy("test/contracts/ConstOverride");
-        assertEq(getCode(deployed_2), hex"6001610420");
+        assertEq(getCode(deployed_2), hex"6020610420");
+
+        // Test bytes32 constant
+        address deployed_3 = HuffDeployer.config()
+            .with_bytes32_constant("a", bytes32(hex"01"))
+            .with_constant("b", "0x420")
+            .deploy("test/contracts/ConstOverride");
+        assertEq(getCode(deployed_3), hex"7f0100000000000000000000000000000000000000000000000000000000000000610420");
+
+        // Keep default "a" value and assign "b", which is unassigned in "ConstOverride.huff"
+        address deployed_4 = HuffDeployer.config()
+            .with_constant("b", "0x420")
+            .deploy("test/contracts/ConstOverride");
+        assertEq(getCode(deployed_4), hex"6001610420");
     }
 
     function getCode(address who) internal view returns (bytes memory o_code) {

--- a/src/test/Logging.t.sol
+++ b/src/test/Logging.t.sol
@@ -9,44 +9,69 @@ import {INumber} from "./interfaces/INumber.sol";
 import {IConstructor} from "./interfaces/IConstructor.sol";
 
 contract LoggingTest is Test {
-  event LogOne();
-  event LogTwo(address indexed a);
-  event LogThree(address indexed a, uint256 indexed b);
-  event LogFour(address indexed a, uint256 indexed b, bytes32 indexed c);
-  event Extended(address indexed a, uint256 indexed b, bytes32 indexed h1, bytes32 h2, bytes32 two);
-
-  function testLoggingWithArgs() public {
-    // Ignore the second topic (address) since the internal HuffConfig is the msg.sender
-    vm.expectEmit(false, true, true, true);
-    emit LogOne();
-    emit LogTwo(address(0));
-    emit LogThree(address(0), 0);
-    emit LogFour(address(0), 0, keccak256(abi.encode(1)));
-    emit Extended(address(0), 0, keccak256(abi.encode(1)), keccak256(abi.encode(2)), keccak256(abi.encode(3)));
-    HuffDeployer.deploy_with_args(
-        "test/contracts/LotsOfLogging",
-        bytes.concat(abi.encode(address(0x420)), abi.encode(uint256(0x420)))
+    event LogOne();
+    event LogTwo(address indexed a);
+    event LogThree(address indexed a, uint256 indexed b);
+    event LogFour(address indexed a, uint256 indexed b, bytes32 indexed c);
+    event Extended(
+        address indexed a,
+        uint256 indexed b,
+        bytes32 indexed h1,
+        bytes32 h2,
+        bytes32 two
     );
-  }
 
-  function testLoggingWithDeploy() public {
-    vm.expectEmit(false, true, true, true);
-    emit LogOne();
-    emit LogTwo(address(0));
-    emit LogThree(address(0), 0);
-    emit LogFour(address(0), 0, keccak256(abi.encode(1)));
-    emit Extended(address(0), 0, keccak256(abi.encode(1)), keccak256(abi.encode(2)), keccak256(abi.encode(3)));
-    HuffDeployer.deploy("test/contracts/LotsOfLogging");
-  }
+    function testLoggingWithArgs() public {
+        // Ignore the second topic (address) since the internal HuffConfig is the msg.sender
+        vm.expectEmit(false, true, true, true);
+        emit LogOne();
+        emit LogTwo(address(0));
+        emit LogThree(address(0), 0);
+        emit LogFour(address(0), 0, keccak256(abi.encode(1)));
+        emit Extended(
+            address(0),
+            0,
+            keccak256(abi.encode(1)),
+            keccak256(abi.encode(2)),
+            keccak256(abi.encode(3))
+            );
+        HuffDeployer.deploy_with_args(
+            "test/contracts/LotsOfLogging",
+            bytes.concat(abi.encode(address(0x420)), abi.encode(uint256(0x420)))
+        );
+    }
 
-  function testConfigLogging() public {
-    HuffConfig config = HuffDeployer.config().with_args(abi.encode(address(0x420)));
-    vm.expectEmit(true, true, true, true);
-    emit LogOne();
-    emit LogTwo(address(config));
-    emit LogThree(address(config), 0);
-    emit LogFour(address(config), 0, keccak256(abi.encode(1)));
-    emit Extended(address(config), 0, keccak256(abi.encode(1)), keccak256(abi.encode(2)), keccak256(abi.encode(3)));
-    config.deploy("test/contracts/LotsOfLogging");
-  }
+    function testLoggingWithDeploy() public {
+        vm.expectEmit(false, true, true, true);
+        emit LogOne();
+        emit LogTwo(address(0));
+        emit LogThree(address(0), 0);
+        emit LogFour(address(0), 0, keccak256(abi.encode(1)));
+        emit Extended(
+            address(0),
+            0,
+            keccak256(abi.encode(1)),
+            keccak256(abi.encode(2)),
+            keccak256(abi.encode(3))
+            );
+        HuffDeployer.deploy("test/contracts/LotsOfLogging");
+    }
+
+    function testConfigLogging() public {
+        HuffConfig config =
+            HuffDeployer.config().with_args(abi.encode(address(0x420)));
+        vm.expectEmit(true, true, true, true);
+        emit LogOne();
+        emit LogTwo(address(config));
+        emit LogThree(address(config), 0);
+        emit LogFour(address(config), 0, keccak256(abi.encode(1)));
+        emit Extended(
+            address(config),
+            0,
+            keccak256(abi.encode(1)),
+            keccak256(abi.encode(2)),
+            keccak256(abi.encode(3))
+            );
+        config.deploy("test/contracts/LotsOfLogging");
+    }
 }

--- a/src/test/contracts/ConstOverride.huff
+++ b/src/test/contracts/ConstOverride.huff
@@ -1,0 +1,6 @@
+#define constant a = 0x01
+
+#define macro MAIN() = takes (0) returns (0) {
+    [a]
+    [b]
+}


### PR DESCRIPTION
# Overview

Adds support for constant overrides, added to the compiler in https://github.com/huff-language/huff-rs/pull/171.

Requires a compiler update- run `huffup -b feat/constant-override` if #171 has not been merged into huff-rs yet.

**Do not merge until #171 in huff-rs is merged & a nightly release with the feature has been made**