### PR TITLE
feat: add broadcast functions

### DIFF
--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -88,7 +88,7 @@ contract HuffConfig {
     }
 
     /// @notice sets whether to broadcast the deployment
-    function set_broadcast(bool broadcast) public Returns (HuffConfig) {
+    function set_broadcast(bool broadcast) public returns (HuffConfig) {
         should_broadcast = true;
         return this;
     }

--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -26,7 +26,7 @@ contract HuffConfig {
     uint256 public value;
 
     /// @notice whether to broadcast the deployment tx
-    bool public broadcast;
+    bool public should_broadcast;
 
     /// @notice constant overrides for the current compilation environment
     Constant[] public const_overrides;
@@ -84,6 +84,12 @@ contract HuffConfig {
         uint256 value
     ) public returns (HuffConfig) {
         const_overrides.push(Constant(key, bytesToString(abi.encodePacked(value))));
+        return this;
+    }
+
+    /// @notice sets whether to broadcast the deployment
+    function set_broadcast(bool broadcast) public Returns (HuffConfig) {
+        should_broadcast = true;
         return this;
     }
 
@@ -199,6 +205,7 @@ contract HuffConfig {
 
         /// @notice deploy the bytecode with the create instruction
         address deployedAddress;
+        if (should_broadcast) vm.broadcast();
         assembly {
             let val := sload(value.slot)
             deployedAddress := create(val, add(concatenated, 0x20), mload(concatenated))
@@ -211,10 +218,5 @@ contract HuffConfig {
 
         /// @notice return the address that the contract was deployed to
         return deployedAddress;
-    }
-
-    function broadcast(string memory file) public payable returns (address) {
-        vm.broadcast();
-        deploy(file);
     }
 }

--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -89,7 +89,7 @@ contract HuffConfig {
 
     /// @notice sets whether to broadcast the deployment
     function set_broadcast(bool broadcast) public returns (HuffConfig) {
-        should_broadcast = true;
+        should_broadcast = broadcast;
         return this;
     }
 

--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -25,6 +25,9 @@ contract HuffConfig {
     /// @notice value to deploy the contract with
     uint256 public value;
 
+    /// @notice whether to broadcast the deployment tx
+    bool public broadcast;
+
     /// @notice constant overrides for the current compilation environment
     Constant[] public const_overrides;
 
@@ -208,5 +211,10 @@ contract HuffConfig {
 
         /// @notice return the address that the contract was deployed to
         return deployedAddress;
+    }
+
+    function broadcast(string memory file) public payable returns (address) {
+        vm.broadcast();
+        deploy(file);
     }
 }

--- a/src/HuffDeployer.sol
+++ b/src/HuffDeployer.sol
@@ -18,8 +18,11 @@ library HuffDeployer {
         return config().deploy(fileName);
     }
 
-    function broadcast(string memory filename) internal returns (address) {
-        return config().set_broadcast(true).deploy(filename);
+    /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
+    /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
+    /// @return The address that the contract was deployed to
+    function broadcast(string memory fileName) internal returns (address) {
+        return config().set_broadcast(true).deploy(fileName);
     }
 
     /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to

--- a/src/HuffDeployer.sol
+++ b/src/HuffDeployer.sol
@@ -5,9 +5,14 @@ import {Vm} from "forge-std/Vm.sol";
 import {HuffConfig} from "./HuffConfig.sol";
 
 library HuffDeployer {
+
+    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
     /// @notice Create a new huff config
     function config() public returns (HuffConfig) {
+        vm.stopBroadcast();
         return new HuffConfig();
+        // vm.startBroadcast();
     }
 
     /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
@@ -15,6 +20,10 @@ library HuffDeployer {
     /// @return The address that the contract was deployed to
     function deploy(string memory fileName) internal returns (address) {
         return config().deploy(fileName);
+    }
+
+    function broadcast(string memory filename) internal returns (address) {
+        return config().set_broadcast(true).deploy(filename);
     }
 
     /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
@@ -30,6 +39,17 @@ library HuffDeployer {
 
     /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
     /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
+    /// @param value - Value to deploy with
+    /// @return The address that the contract was deployed to
+    function broadcast_with_value(
+        string memory fileName,
+        uint256 value
+    ) internal returns (address) {
+        return config().set_broadcast(true).with_value(value).deploy(fileName);
+    }
+
+    /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
+    /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
     /// @param args - Constructor Args to append to the bytecode
     /// @return The address that the contract was deployed to
     function deploy_with_args(
@@ -37,6 +57,17 @@ library HuffDeployer {
         bytes memory args
     ) internal returns (address) {
         return config().with_args(args).deploy(fileName);
+    }
+
+    /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
+    /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
+    /// @param args - Constructor Args to append to the bytecode
+    /// @return The address that the contract was deployed to
+    function broadcast_with_args(
+        string memory fileName,
+        bytes memory args
+    ) internal returns (address) {
+        return config().set_broadcast(true).with_args(args).deploy(fileName);
     }
 
     /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
@@ -53,6 +84,17 @@ library HuffDeployer {
     /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
     /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
     /// @param code - Code to append to the file source code (e.g. a constructor macro to make the contract instantiable)
+    /// @return The address that the contract was deployed to
+    function broadcast_with_code(
+        string memory fileName, 
+        string memory code
+    ) internal returns (address) {
+        return config().set_broadcast(true).with_code(code).deploy(fileName);
+    }
+
+    /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
+    /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
+    /// @param code - Code to append to the file source code (e.g. a constructor macro to make the contract instantiable)
     /// @param args - Constructor Args to append to the bytecode
     /// @return The address that the contract was deployed to
     function deploy_with_code_args(
@@ -61,5 +103,18 @@ library HuffDeployer {
         bytes memory args
     ) internal returns (address) {
         return config().with_code(code).with_args(args).deploy(fileName);
+    }
+
+    /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
+    /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
+    /// @param code - Code to append to the file source code (e.g. a constructor macro to make the contract instantiable)
+    /// @param args - Constructor Args to append to the bytecode
+    /// @return The address that the contract was deployed to
+    function broadcast_with_code_args(
+        string memory fileName,
+        string memory code,
+        bytes memory args
+    ) internal returns (address) {
+        return config().set_broadcast(true).with_code(code).with_args(args).deploy(fileName);
     }
 }

--- a/src/HuffDeployer.sol
+++ b/src/HuffDeployer.sol
@@ -6,13 +6,9 @@ import {HuffConfig} from "./HuffConfig.sol";
 
 library HuffDeployer {
 
-    Vm constant vm = Vm(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
-
     /// @notice Create a new huff config
     function config() public returns (HuffConfig) {
-        vm.stopBroadcast();
         return new HuffConfig();
-        // vm.startBroadcast();
     }
 
     /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to

--- a/src/test/HuffConfig.t.sol
+++ b/src/test/HuffConfig.t.sol
@@ -39,4 +39,10 @@ contract HuffConfigTest is Test {
         assertEq(key, k);
         assertEq(value, v);
     }
+
+    function testSetBroadcast(bool broadcast) public {
+        config.set_broadcast(broadcast);
+        bool b = config.should_broadcast();
+        assertEq(b, broadcast);
+    }
 }


### PR DESCRIPTION
Adds versions of the deploy functions that will broadcast the tx. This needs to be done since if you try to use the `broadcast` cheatcode, it will broadcast the deployment of `HuffConfig`.

One thing to note here is that if you do a raw `HuffDeployer.config().set_broadcast(true).deploy("Contract")`  in your script, it still will broadcast the `HuffConfig` contract. As far as I can tell this is a bug in Foundry having something to do with the interaction between broadcast and DELEGATECALL, but let me know if there is some other valid reason for this behavior.

fixes #21 