### PR TITLE
Feat: Ability to set deploy caller

### DIFF
--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -25,6 +25,10 @@ contract HuffConfig {
     /// @notice value to deploy the contract with
     uint256 public value;
 
+    /// @notice address that will be the `msg.sender` (op: caller) in the constructor
+    /// @dev set to config address to ensure backwards compatibility
+    address public deployer = address(this);
+
     /// @notice constant overrides for the current compilation environment
     Constant[] public const_overrides;
 
@@ -43,6 +47,12 @@ contract HuffConfig {
     /// @notice sets the amount of wei to deploy the contract with
     function with_value(uint256 _value) public returns (HuffConfig) {
         value = _value;
+        return this;
+    }
+
+    /// @notice sets the caller of the next deployment
+    function with_deployer(address _deployer) public returns (HuffConfig) {
+        deployer = _deployer;
         return this;
     }
 
@@ -193,6 +203,9 @@ contract HuffConfig {
         cleanup[0] = "rm";
         cleanup[1] = string.concat("src/", tempFile, ".huff");
         vm.ffi(cleanup);
+
+        // set `msg.sender` for upcoming create context
+        vm.prank(deployer);
 
         /// @notice deploy the bytecode with the create instruction
         address deployedAddress;

--- a/src/test/HuffConfig.t.sol
+++ b/src/test/HuffConfig.t.sol
@@ -15,6 +15,11 @@ contract HuffConfigTest is Test {
         config = new HuffConfig();
     }
 
+    function testWithDeployer(address deployer) public {
+        config.with_deployer(deployer);
+        assertEq(config.deployer(), deployer);
+    }
+
     function testWithArgs(bytes memory some) public {
         config.with_args(some);
         assertEq(config.args(), some);

--- a/src/test/HuffDeployer.t.sol
+++ b/src/test/HuffDeployer.t.sol
@@ -150,7 +150,7 @@ contract HuffDeployerTest is Test {
         assertEq(rememberer.CREATOR(), address(config));
     }
 
-    function testConstructorCaller(address deployer) public {
+    function runTestConstructorCaller(address deployer) public {
         IRememberCreator rememberer = IRememberCreator(
             HuffDeployer
                 .config()
@@ -158,5 +158,13 @@ contract HuffDeployerTest is Test {
                 .deploy("test/contracts/RememberCreator")
         );
         assertEq(rememberer.CREATOR(), deployer);
+    }
+
+    // @dev fuzzed test too slow, random examples and address(0) chosen
+    function testConstructorCaller() public {
+        runTestConstructorCaller(address(uint160(uint256(keccak256("random addr 1")))));
+        runTestConstructorCaller(address(uint160(uint256(keccak256("random addr 2")))));
+        runTestConstructorCaller(address(0));
+        runTestConstructorCaller(address(uint160(0x1000)));
     }
 }

--- a/src/test/HuffDeployer.t.sol
+++ b/src/test/HuffDeployer.t.sol
@@ -7,6 +7,7 @@ import {HuffConfig} from "../HuffConfig.sol";
 import {HuffDeployer} from "../HuffDeployer.sol";
 import {INumber} from "./interfaces/INumber.sol";
 import {IConstructor} from "./interfaces/IConstructor.sol";
+import {IRememberCreator} from "./interfaces/IRememberCreator.sol";
 
 contract HuffDeployerTest is Test {
     INumber number;
@@ -141,5 +142,21 @@ contract HuffDeployerTest is Test {
     function testSet(uint256 num) public {
         number.setNumber(num);
         assertEq(num, number.getNumber());
+    }
+
+    function testConstructorDefaultCaller() public {
+        HuffConfig config = HuffDeployer.config();
+        IRememberCreator rememberer = IRememberCreator(config.deploy("test/contracts/RememberCreator"));
+        assertEq(rememberer.CREATOR(), address(config));
+    }
+
+    function testConstructorCaller(address deployer) public {
+        IRememberCreator rememberer = IRememberCreator(
+            HuffDeployer
+                .config()
+                .with_deployer(deployer)
+                .deploy("test/contracts/RememberCreator")
+        );
+        assertEq(rememberer.CREATOR(), deployer);
     }
 }

--- a/src/test/contracts/RememberCreator.huff
+++ b/src/test/contracts/RememberCreator.huff
@@ -1,0 +1,24 @@
+#define constant CREATOR_SLOT = FREE_STORAGE_POINTER()
+
+#define function CREATOR() view returns (address)
+
+#define macro CONSTRUCTOR() = takes(0) returns(0) {
+    caller [CREATOR_SLOT] sstore
+}
+
+#define macro MAIN() = takes(0) returns(0) {
+    0x00 calldataload 0xE0 shr // [selector]
+    __FUNC_SIG(CREATOR) eq get_creator jumpi
+
+    // no selector matched, revert
+    base_error:
+        returndatasize returndatasize revert
+
+    get_creator:
+        // check no call value
+        callvalue base_error jumpi
+        // read and return creator
+        [CREATOR_SLOT] sload   // [creator]
+        returndatasize mstore  // []
+        0x20 returndatasize return
+}

--- a/src/test/interfaces/IRememberCreator.sol
+++ b/src/test/interfaces/IRememberCreator.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity >=0.7.0 <0.9.0;
+
+interface IRememberCreator {
+    function CREATOR() view returns (address);
+}

--- a/src/test/interfaces/IRememberCreator.sol
+++ b/src/test/interfaces/IRememberCreator.sol
@@ -2,5 +2,5 @@
 pragma solidity >=0.7.0 <0.9.0;
 
 interface IRememberCreator {
-    function CREATOR() view returns (address);
+    function CREATOR() external view returns (address);
 }


### PR DESCRIPTION
**Problem**
Currently it is not possible to change the `msg.sender` (op: `caller`) of the create transaction for Huff contracts, when using `HuffConfig` / `HuffDeployer`. This is necessary when testing contracts which contain caller dependent logic in the constructor.

**Changes made**
This PR adds a `.with_deployer(address)` method to the `HuffConfig` contract which sets the address to be set as the caller for any upcoming contract deployments from that config contract. The default address is the config contract itself, this is done mainly so that the existing behavior is mimicked by default, the change is therefore backwards compatible. The caller is set via foundry's [`vm.prank`](https://book.getfoundry.sh/cheatcodes/prank) cheatcode.

**Testing**
Tests have been added for the included changes.

**Potential Improvements**
The `HuffDeployer` library could be extended with more utility methods to allow for direct setting of the caller without having to interact with `HuffConfig`.