### PR TITLE
Fix `_` prefix and `a` prefix

### DIFF
--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -44,8 +44,8 @@ contract HuffConfig {
     }
 
     /// @notice sets the amount of wei to deploy the contract with
-    function with_value(uint256 _value) public returns (HuffConfig) {
-        value = _value;
+    function with_value(uint256 value_) public returns (HuffConfig) {
+        value = value_;
         return this;
     }
 

--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -32,14 +32,14 @@ contract HuffConfig {
     Constant[] public const_overrides;
 
     /// @notice sets the code to be appended to the source file
-    function with_code(string memory acode) public returns (HuffConfig) {
-        code = acode;
+    function with_code(string memory code_) public returns (HuffConfig) {
+        code = code_;
         return this;
     }
 
     /// @notice sets the arguments to be appended to the bytecode
-    function with_args(bytes memory aargs) public returns (HuffConfig) {
-        args = aargs;
+    function with_args(bytes memory args_) public returns (HuffConfig) {
+        args = args_;
         return this;
     }
 


### PR DESCRIPTION
Related: #27

I found the `_` prefix and these `a` prefixes while creating #27. Unlike #27, this PR is not important, but I'm reporting it.

As https://github.com/ethereum/solidity/pull/12680 states, a `_` prefix and an `a` prefix should be changed to a `_` suffix.

> Used when shadowing an existing variable or function name. The style guide currently states the _ suffix should be used when the name collides with a reserved word and there is a proposal to expand this definition to include collisions with function and state variable names. In these cases, the pr changes the variable name from a _prefix to a suffix_