### PR TITLE
Fixed Linter: Add config_with_create_2 and get_config_with_create_2 for deterministic HuffConfig deployment

### DIFF
--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -129,11 +129,11 @@ contract HuffConfig {
         return string(str);
     }
 
-    /// @notice Deploy the Contract
-    function deploy(string memory file) public payable returns (address) {
+    /// @notice Get the creation bytecode of a contract
+    function creation_code(string memory file) public payable returns (bytes memory bytecode) {
         binary_check();
 
-        // Split the file into it's parts
+        // Split the file into its parts
         strings.slice memory s = file.toSlice();
         strings.slice memory delim = "/".toSlice();
         string[] memory parts = new string[](s.count(delim) + 1);
@@ -194,15 +194,24 @@ contract HuffConfig {
         cmds[2] = "-b";
 
         /// @notice compile the Huff contract and return the bytecode
-        bytes memory bytecode = vm.ffi(cmds);
-        bytes memory concatenated = bytes.concat(bytecode, args);
+        bytecode = vm.ffi(cmds);
 
         // Clean up temp files
         string[] memory cleanup = new string[](2);
         cleanup[0] = "rm";
         cleanup[1] = string.concat("src/", tempFile, ".huff");
         vm.ffi(cleanup);
+    }
 
+    /// @notice get creation code of a contract plus encoded arguments
+    function creation_code_with_args(string memory file) public payable returns (bytes memory bytecode) {
+        bytecode = creation_code(file);
+        return bytes.concat(bytecode, args);
+    }
+
+    /// @notice Deploy the Contract
+    function deploy(string memory file) public payable returns (address) {
+        bytes memory concatenated = creation_code_with_args(file);
         /// @notice deploy the bytecode with the create instruction
         address deployedAddress;
         if (should_broadcast) vm.broadcast();

--- a/src/HuffDeployer.sol
+++ b/src/HuffDeployer.sol
@@ -11,6 +11,27 @@ library HuffDeployer {
         return new HuffConfig();
     }
 
+    // @notice Deterministically create a new huff config using create2 and a salt
+    function config_with_create_2(uint256 salt) public returns (HuffConfig) {
+        return new HuffConfig{salt: bytes32(salt)}();
+    }
+
+    // @notice Get the address of a HuffConfig deployed with config_with_create_2
+    function get_config_with_create_2(uint256 salt) public view returns (address) {
+        return 
+            address(
+                uint160(
+                    uint256(
+                        keccak256(
+                            abi.encodePacked(
+                                bytes1(0xff), address(this), bytes32(salt), keccak256(type(HuffConfig).creationCode)
+                            )
+                        )
+                    )
+                )
+            );
+    }
+
     /// @notice Compiles a Huff contract and returns the address that the contract was deployeod to
     /// @param fileName - The file name of the Huff contract. For example, the file name for "SimpleStore.huff" is "SimpleStore"
     /// @return The address that the contract was deployed to

--- a/src/test/HuffDeployer.t.sol
+++ b/src/test/HuffDeployer.t.sol
@@ -69,6 +69,41 @@ contract HuffDeployerTest is Test {
         assertEq(uint256(0x420), chained.getArgTwo());
     }
 
+    function testChaining_Create2() public {
+        // Defined Constructor
+        string memory constructor_macro = "#define macro CONSTRUCTOR() = takes(0) returns (0) {"
+            "    // Copy the first argument into memory \n"
+            "    0x20                        // [size] - byte size to copy \n"
+            "    0x40 codesize sub           // [offset, size] - offset in the code to copy from\n "
+            "    0x00                        // [mem, offset, size] - offset in memory to copy to \n"
+            "    codecopy                    // [] \n" "    // Store the first argument in storage\n"
+            "    0x00 mload dup1             // [arg1, arg1] \n"
+            "    [CONSTRUCTOR_ARG_ONE]       // [CONSTRUCTOR_ARG_ONE, arg1, arg1] \n"
+            "    sstore                      // [arg1] \n" "    // Copy the second argument into memory \n"
+            "    0x20                        // [size, arg1] - byte size to copy \n"
+            "    0x20 codesize sub           // [offset, size, arg1] - offset in the code to copy from \n"
+            "    0x00                        // [mem, offset, size, arg1] - offset in memory to copy to \n"
+            "    codecopy                    // [arg1] \n" "    // Store the second argument in storage \n"
+            "    0x00 mload dup1             // [arg2, arg2, arg1] \n"
+            "    [CONSTRUCTOR_ARG_TWO]       // [CONSTRUCTOR_ARG_TWO, arg2, arg2, arg1] \n"
+            "    sstore                      // [arg2, arg1] \n" "    // Emit the owner updated event \n"
+            "    swap1                            // [arg1, arg2] \n"
+            "    [ARGUMENTS_TOPIC]                // [sig, arg1, arg2] \n"
+            "    0x00 0x00                        // [0, 0, sig, arg1, arg2] \n"
+            "    log3                             // [] \n" "}";
+
+        // New pattern
+        vm.expectEmit(true, true, true, true);
+        emit ArgumentsUpdated(address(0x420), uint256(0x420));
+        IConstructor chained = IConstructor(
+            HuffDeployer.config_with_create_2(1).with_args(bytes.concat(abi.encode(address(0x420)), abi.encode(uint256(0x420))))
+                .with_code(constructor_macro).deploy("test/contracts/NoConstructor")
+        );
+
+        assertEq(address(0x420), chained.getArgOne());
+        assertEq(uint256(0x420), chained.getArgTwo());
+    }
+
     function testArgOne() public {
         assertEq(address(0x420), structor.getArgOne());
     }
@@ -89,6 +124,11 @@ contract HuffDeployerTest is Test {
         HuffDeployer.config()
             .with_value(value)
             .deploy{value: value}("test/contracts/ConstructorNeedsValue");
+    }
+
+    function testWithValueDeployment_Create2() public {
+        uint256 value = 1 ether;
+        HuffDeployer.config_with_create_2(1).with_value(value).deploy{value: value}("test/contracts/ConstructorNeedsValue");
     }
 
     function testConstantOverride() public {
@@ -118,6 +158,31 @@ contract HuffDeployerTest is Test {
         address deployed_4 = HuffDeployer.config()
             .with_constant("b", "0x420")
             .deploy("test/contracts/ConstOverride");
+        assertEq(getCode(deployed_4), hex"6001610420");
+    }
+
+    function testConstantOverride_Create2() public {
+        // Test address constant
+        address a = 0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF;
+        address deployed = HuffDeployer.config_with_create_2(1).with_addr_constant("a", a).with_constant("b", "0x420").deploy(
+            "test/contracts/ConstOverride"
+        );
+        assertEq(getCode(deployed), hex"73DeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF610420");
+
+        // Test uint constant
+        address deployed_2 = HuffDeployer.config_with_create_2(2).with_uint_constant("a", 32).with_constant("b", "0x420").deploy(
+            "test/contracts/ConstOverride"
+        );
+        assertEq(getCode(deployed_2), hex"6020610420");
+
+        // Test bytes32 constant
+        address deployed_3 = HuffDeployer.config_with_create_2(3).with_bytes32_constant("a", bytes32(hex"01")).with_constant(
+            "b", "0x420"
+        ).deploy("test/contracts/ConstOverride");
+        assertEq(getCode(deployed_3), hex"7f0100000000000000000000000000000000000000000000000000000000000000610420");
+
+        // Keep default "a" value and assign "b", which is unassigned in "ConstOverride.huff"
+        address deployed_4 = HuffDeployer.config_with_create_2(4).with_constant("b", "0x420").deploy("test/contracts/ConstOverride");
         assertEq(getCode(deployed_4), hex"6001610420");
     }
 


### PR DESCRIPTION
Adding config_with_create_2(uint256) and get_config_with_create_2(uint256) lets devs deterministically get and deploy the address where HuffConfig will be deployed to, rather than hardcoding an address.

For example, when trying to fix TSOwnable.t.sol in huffmate which was failing it was because of the hardcoded HuffConfig address. I fixed it locally using config2. To make a pull request to huffmate these methods are needed...

Works the same way as config but uses create2 and a salt in uint256 to ease usage