### PR TITLE
Console.log functionality for debugging huff contracts

### DIFF
--- a/src/Console.huff
+++ b/src/Console.huff
@@ -1,0 +1,472 @@
+/// @title Console
+/// @notice SPDX-License-Identifier: MIT
+/// @author AmadiMichael <https://github.com/AmadiMichael>
+/// @notice Console.log functionalities for huff/bytecode written contracts compiled using foundry
+
+
+
+
+//////////////////////  STYLE=STD CONSTANTS  /////////////////////////////
+
+
+#define constant RED = 0x1b5b39316d000000000000000000000000000000000000000000000000000000
+#define constant GREEN = 0x1b5b39326d000000000000000000000000000000000000000000000000000000
+#define constant YELLOW = 0x1b5b39336d000000000000000000000000000000000000000000000000000000
+#define constant BLUE = 0x1b5b39346d000000000000000000000000000000000000000000000000000000
+#define constant MAGENTA = 0x1b5b39356d000000000000000000000000000000000000000000000000000000
+#define constant CYAN = 0x1b5b39366d000000000000000000000000000000000000000000000000000000
+#define constant BOLD = 0x1b5b316d00000000000000000000000000000000000000000000000000000000
+#define constant DIM = 0x1b5b326d00000000000000000000000000000000000000000000000000000000
+#define constant ITALIC = 0x1b5b336d00000000000000000000000000000000000000000000000000000000
+#define constant UNDERLINE = 0x1b5b346d00000000000000000000000000000000000000000000000000000000
+#define constant INVERSE = 0x1b5b376d00000000000000000000000000000000000000000000000000000000
+#define constant RESET = 0x1b5b306d00000000000000000000000000000000000000000000000000000000
+
+
+
+
+
+
+//////////////////////  EXPERIMENTAL (STYLE-STD)  /////////////////////////////
+
+
+/// @notice EXPERIMENTAL FEATURE
+/// @notice can be used to create a line break to help differentiate between different logs
+/// @dev @param start is the offset to pre store line break bytecode in memory
+/// @dev @param mem_ptr is free memory location to be used for logging operations (would take more than 32 bytes)
+#define macro LINE_BREAK(start, mem_ptr) = {
+    // "0a" is hex for "\n" which breaks into a new line
+    __RIGHTPAD(0x0a) <start> mstore
+    // logs out memory as bytes from offset 0x00 till offset 0x00 + 0x06 bytes and uses memory offset 0x20 for logging operations
+    LOG_MEMORY_AS_STRING(<start>, 0x01, <mem_ptr>)
+}
+ 
+
+/// @notice EXPERIMENTAL FEATURE
+/// @notice styled logs is still experimental
+/// @notice console log the first item of the stack 
+/// @dev @param style is the offset in memory where the color signature is stored
+#define macro LOG_MEMORY_AS_STRING_STYLE(start, size, mem_ptr, style) = {
+    0x41304fac00000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+
+    0x20 <mem_ptr> 0x04 add mstore
+    <size> 0x09 add <mem_ptr> 0x24 add mstore
+
+    <style> mload <mem_ptr> 0x44 add mstore
+    
+    <size> <mem_ptr> 0x49 add <size> <start> 0x04 gas 
+    staticcall pop
+
+    0x1b5b306d00000000000000000000000000000000000000000000000000000000 <mem_ptr> 0x49 <size> add add mstore
+
+    0x00 0x00 <size> 0x4d add <mem_ptr> 0x000000000000000000636F6e736F6c652e6c6f67 gas 
+    staticcall pop
+}
+
+
+
+
+
+
+
+//////////////////////  MEMORY  /////////////////////////////
+
+
+/// @notice console log memory from `start` to (`start` + `size`) as bytes
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_MEMORY(start, size, mem_ptr) = {
+    0x0be77f5600000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    _LOG_MEMORY(<start>, <size>, <mem_ptr>)
+}
+
+
+/// @notice console log memory between start to (start + size) as string
+/// @dev the length pointer and length are added automatically here so `start` 
+/// should be the offset of the actual data and not the offset of the length or length pointer
+/// To see the full data (length included), use LOG_MEMORY
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_MEMORY_AS_STRING(start, size, mem_ptr) = {
+    0x41304fac00000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    _LOG_MEMORY(<start>, <size>, <mem_ptr>)
+}
+
+
+
+
+
+
+
+
+//////////////////////  CALLDATA  /////////////////////////////
+
+
+/// @notice console log calldata from `start` to (`start` + `size`) as bytes
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_CALLDATA(start, size, mem_ptr) = {
+    0x0be77f5600000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    _LOG_CALLDATA(<start>, <size>, <mem_ptr>)
+}
+
+/// @notice console log calldata between start to (start + size) as string
+/// @dev the length pointer and length are added automatically here so `start` 
+/// should be the offset of the actual data and not the offset of the length or length pointer
+/// To see the full data (pointer and length included), use LOG_CALLDATA
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_CALLDATA_AS_STRING(start, size, mem_ptr) = {
+    0x41304fac00000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    _LOG_CALLDATA(<start>, <size>, <mem_ptr>)
+
+}
+
+
+//////////////////////  CALLDATA (TYPES) /////////////////////////////
+
+
+/// @notice console log calldata from `start` to (`start` + `size`) as uint256
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_CALLDATA_AS_UINT(start, mem_ptr) = {
+    0xf5b1bba900000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_CALLDATA_TYPE(<start>, <mem_ptr>)
+}
+
+/// @notice console log calldata from `start` to (`start` + `size`) as int256
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_CALLDATA_AS_INT(start, mem_ptr) = {
+    0x4e0c1d1d00000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_CALLDATA_TYPE(<start>, <mem_ptr>)
+}
+
+/// @notice console log calldata from `start` to (`start` + `size`) as an address
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_CALLDATA_AS_ADDRESS(start, mem_ptr) = {
+    0x2c2ecbc200000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_CALLDATA_TYPE(<start>, <mem_ptr>)
+}
+
+/// @notice console log calldata from `start` to (`start` + `size`) as a bytes32
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_CALLDATA_AS_BYTES32(start, mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_CALLDATA_TYPE(<start>, <mem_ptr>)
+}
+
+/// @notice console log calldata from `start` to (`start` + `size`) as a boolean
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+/// @dev only 0x01 is seen as true in this case. meaning 0x00 and any value greater than 0x02 will log out false
+#define macro LOG_CALLDATA_AS_BOOL(start, mem_ptr) = {
+    0x32458eed00000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_CALLDATA_TYPE(<start>, <mem_ptr>)
+}
+
+
+
+
+
+
+
+//////////////////////  STACK (TYPES)  /////////////////////////////
+
+
+/// @notice console log stack item `N`as uint256
+/// @dev @param dupN should be any dup opcode from dup1 to dup16
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_STACK_AS_UINT(dupN, mem_ptr) = {
+    0xf5b1bba900000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(<dupN>, <mem_ptr>)
+}
+
+/// @notice console log stack item `N`as int256
+/// @dev @param dupN should be any dup opcode from dup1 to dup16
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_STACK_AS_INT(dupN, mem_ptr) = {
+    0x4e0c1d1d00000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(<dupN>, <mem_ptr>)
+}
+
+/// @notice console log stack item `N`as an address
+/// @dev @param dupN should be any dup opcode from dup1 to dup16
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_STACK_AS_ADDRESS(dupN, mem_ptr) = {
+    0x2c2ecbc200000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(<dupN>, <mem_ptr>)
+}
+
+/// @notice console log stack item `N`as bytes32
+/// @dev @param dupN should be any dup opcode from dup1 to dup16
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+#define macro LOG_STACK_AS_BYTES32(dupN, mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(<dupN>, <mem_ptr>)
+}
+
+/// @notice console log stack item `N`as a boolean
+/// @dev @param dupN should be any dup opcode from dup1 to dup16
+/// @dev @param mem_ptr is the memory offset to be used by the macro, should be safe to use to avoid overriding useful memory data
+/// @dev only 0x01 is seen as true in this case. meaning 0x00 and any value greater than 0x02 will log out false. Consider logging as a uint too.
+#define macro LOG_STACK_AS_BOOL(dupN, mem_ptr) = {
+    0x32458eed00000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(<dupN>, <mem_ptr>)
+}
+
+
+
+
+
+//////////////////////  STACK  /////////////////////////////
+
+
+/// @notice console log the first item of the stack 
+#define macro LOG_STACK_1(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+}
+
+/// @notice console log the first 2 items of the stack 
+#define macro LOG_STACK_2(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+}
+
+/// @notice console log the first 3 items of the stack 
+#define macro LOG_STACK_3(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+}
+
+/// @notice console log the first 4 items of the stack 
+#define macro LOG_STACK_4(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+}
+
+/// @notice console log the first 5 items of the stack 
+#define macro LOG_STACK_5(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+}
+
+/// @notice console log the first 6 items of the stack 
+#define macro LOG_STACK_6(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+}
+
+/// @notice console log the first 7 items of the stack 
+#define macro LOG_STACK_7(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+}
+
+/// @notice console log the first 8 items of the stack 
+#define macro LOG_STACK_8(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+    LOG_STACK(dup8, <mem_ptr>)
+}
+
+/// @notice console log the first 9 items of the stack 
+#define macro LOG_STACK_9(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+    LOG_STACK(dup8, <mem_ptr>)
+    LOG_STACK(dup9, <mem_ptr>)
+}
+
+/// @notice console log the first 10 items of the stack 
+#define macro LOG_STACK_10(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+    LOG_STACK(dup8, <mem_ptr>)
+    LOG_STACK(dup9, <mem_ptr>)
+    LOG_STACK(dup10, <mem_ptr>)
+}
+
+/// @notice console log the first 11 items of the stack 
+#define macro LOG_STACK_11(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+    LOG_STACK(dup8, <mem_ptr>)
+    LOG_STACK(dup9, <mem_ptr>)
+    LOG_STACK(dup10, <mem_ptr>)
+    LOG_STACK(dup11, <mem_ptr>)
+}
+
+/// @notice console log the first 12 items of the stack 
+#define macro LOG_STACK_12(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+    LOG_STACK(dup8, <mem_ptr>)
+    LOG_STACK(dup9, <mem_ptr>)
+    LOG_STACK(dup10, <mem_ptr>)
+    LOG_STACK(dup11, <mem_ptr>)
+    LOG_STACK(dup12, <mem_ptr>)
+}
+
+/// @notice console log the first 13 items of the stack 
+#define macro LOG_STACK_13(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+    LOG_STACK(dup8, <mem_ptr>)
+    LOG_STACK(dup9, <mem_ptr>)
+    LOG_STACK(dup10, <mem_ptr>)
+    LOG_STACK(dup11, <mem_ptr>)
+    LOG_STACK(dup12, <mem_ptr>)
+    LOG_STACK(dup13, <mem_ptr>)
+}
+
+/// @notice console log the first 14 items of the stack 
+#define macro LOG_STACK_14(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+    LOG_STACK(dup8, <mem_ptr>)
+    LOG_STACK(dup9, <mem_ptr>)
+    LOG_STACK(dup10, <mem_ptr>)
+    LOG_STACK(dup11, <mem_ptr>)
+    LOG_STACK(dup12, <mem_ptr>)
+    LOG_STACK(dup13, <mem_ptr>)
+    LOG_STACK(dup14, <mem_ptr>)
+}
+
+/// @notice console log the first 15 items of the stack 
+#define macro LOG_STACK_15(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+    LOG_STACK(dup8, <mem_ptr>)
+    LOG_STACK(dup9, <mem_ptr>)
+    LOG_STACK(dup10, <mem_ptr>)
+    LOG_STACK(dup11, <mem_ptr>)
+    LOG_STACK(dup12, <mem_ptr>)
+    LOG_STACK(dup13, <mem_ptr>)
+    LOG_STACK(dup14, <mem_ptr>)
+    LOG_STACK(dup15, <mem_ptr>)
+}
+
+/// @notice console log the first 16 items of the stack 
+#define macro LOG_STACK_16(mem_ptr) = {
+    0x27b7cf8500000000000000000000000000000000000000000000000000000000 <mem_ptr> mstore
+    LOG_STACK(dup1, <mem_ptr>)
+    LOG_STACK(dup2, <mem_ptr>)
+    LOG_STACK(dup3, <mem_ptr>)
+    LOG_STACK(dup4, <mem_ptr>)
+    LOG_STACK(dup5, <mem_ptr>)
+    LOG_STACK(dup6, <mem_ptr>)
+    LOG_STACK(dup7, <mem_ptr>)
+    LOG_STACK(dup8, <mem_ptr>)
+    LOG_STACK(dup9, <mem_ptr>)
+    LOG_STACK(dup10, <mem_ptr>)
+    LOG_STACK(dup11, <mem_ptr>)
+    LOG_STACK(dup12, <mem_ptr>)
+    LOG_STACK(dup13, <mem_ptr>)
+    LOG_STACK(dup14, <mem_ptr>)
+    LOG_STACK(dup15, <mem_ptr>)
+    LOG_STACK(dup16, <mem_ptr>)
+}
+
+
+
+
+
+//////////////////////  UTILS  /////////////////////////////
+
+#define macro _LOG_MEMORY(start, size, mem_ptr) = {
+    0x20 <mem_ptr> 0x04 add mstore
+    <size> <mem_ptr> 0x24 add mstore
+    <size> <mem_ptr> 0x44 add <size> <start> 0x04 gas 
+    staticcall pop
+
+    <size> 0x44 add STATIC_LOG(dup3, <mem_ptr>) pop
+}
+
+#define macro _LOG_CALLDATA(start, size, mem_ptr) = {
+    0x20 <mem_ptr> 0x04 add mstore
+    <size> <mem_ptr> 0x24 add mstore
+    <size> <start> <mem_ptr> 0x44 add calldatacopy
+
+    <size> 0x44 add STATIC_LOG(dup3, <mem_ptr>) pop
+}
+
+
+#define macro LOG_CALLDATA_TYPE(start, mem_ptr) = {
+    0x20 <start> <mem_ptr> 0x04 add calldatacopy
+
+    STATIC_LOG(0x24, <mem_ptr>)
+}
+
+#define macro LOG_STACK(dupN, mem_ptr) = {
+    <dupN> <mem_ptr> 0x04 add mstore
+
+    STATIC_LOG(0x24, <mem_ptr>)
+}
+
+#define macro STATIC_LOG(length, mem_ptr) = {
+    0x00 0x00 <length> <mem_ptr> 0x000000000000000000636F6e736F6c652e6c6f67 gas staticcall pop
+}

--- a/src/test/Console.t.sol
+++ b/src/test/Console.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+import {HuffConfig} from "../HuffConfig.sol";
+import {HuffDeployer} from "../HuffDeployer.sol";
+
+interface Examples {
+    function logTest(
+        uint256 start,
+        uint256 size,
+        uint256 mem_ptr
+    ) external pure;
+}
+
+contract ConsoleTests is Test {
+    Examples public examples;
+
+    function setUp() public {
+        examples = Examples(
+            HuffDeployer.config().deploy("test/contracts/HuffConsoleWrapper")
+        );
+    }
+
+    function testLog() public {
+        // 71752852194630 = 0x414243444546
+        vm.roll(9);
+
+        examples.logTest(71752852194630, 32, 256);
+    }
+}

--- a/src/test/contracts/HuffConsoleWrapper.huff
+++ b/src/test/contracts/HuffConsoleWrapper.huff
@@ -1,0 +1,256 @@
+#include "../../Console.huff"
+
+#define function logTest(uint256, uint256, uint256) pure returns (uint256)
+
+#define macro MAIN() = {
+    0x00 calldataload 0xE0 shr              // [sig]
+    dup1 __FUNC_SIG(logTest) eq logTestJump jumpi
+    0x00 0x00 revert
+    logTestJump:
+        LOG_TEST()
+}
+
+#define macro LOG_TEST() = {
+    __RIGHTPAD(0x4c4f472043414c4c44415441) 0x00 mstore
+    [RED] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0c, 0x40, 0x20)
+    // logs out calldata as bytes from offset 0x04 till 0x04 + 0x60 bytes and uses memory offset 0x00 for logging operations
+    LOG_CALLDATA(0x04, 0x60, 0x00)
+
+
+
+    LINE_BREAK(0x00, 0x20)
+    __RIGHTPAD(0x4c4f472043414c4c44415441205459504553) 0x00 mstore
+    [GREEN] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x12, 0x40, 0x20)
+
+    LOG_CALLDATA_AS_UINT(0x04, 0x00)
+    LOG_CALLDATA_AS_ADDRESS(0x04, 0x00)
+    LOG_CALLDATA_AS_BYTES32(0x04, 0x00)
+    LOG_CALLDATA_AS_INT(0x04, 0x00)
+    // logs out calldata as bytes from offset 0x04 till 0x04 + 0x20 bytes and uses memory offset 0x00 for logging operations
+    LOG_CALLDATA_AS_STRING(0x04, 0x20, 0x00)
+    
+    
+
+    LINE_BREAK(0x00, 0x20)
+    __RIGHTPAD(0x4c4f47204d454d4f5259) 0x00 mstore
+    [YELLOW] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0a, 0x40, 0x20)
+    __RIGHTPAD(0x4142434445464748494a4b4c4d4e4f505152535455565758595a) 0x00 mstore
+    // logs out memory as bytes from offset 0x00 till offset 0x00 + 0x06 bytes and uses memory offset 0x20 for logging operations
+    LOG_MEMORY(0x00, 0x1a, 0xa0)
+
+
+
+    LINE_BREAK(0x00, 0x20)
+    __RIGHTPAD(0x4c4f47204d454d4f525920415320535452494e47) 0x00 mstore
+    [BLUE] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x14, 0x40, 0x20)
+    __RIGHTPAD(0x4142434445464748494a4b4c4d4e4f505152535455565758595a) 0x00 mstore
+    // logs out memory as string from offset 0x00 till offset 0x00 + 0x06 bytes and uses memory offset 0x20 for logging operations
+    LOG_MEMORY_AS_STRING(0x00, 0x1a, 0x20)
+
+
+
+    LINE_BREAK(0x00, 0x20)
+    __RIGHTPAD(0x4c4f47204d454d4f525920415320535452494e47205354594c45) 0x00 mstore
+    [MAGENTA] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x1a, 0x40, 0x20)
+    // STYLE_LOGGING
+    // store the signature of the style type in memory
+    [CYAN] 0x20 mstore
+    __RIGHTPAD(0x4142434445464748494a4b4c4d4e4f505152535455565758595a) 0x00 mstore
+    // logs out memory as string from offset 0x00 till offset 0x00 + 0x06 bytes, uses memory offset 0x40 for logging operations 
+    // and the ;ast parameter specifies the offset where the styling signature is stored.
+    // notice it uses memory offset 0x40 for logging operations rather than 0x20, thats because 0x20 in this case is used to store the style sig
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x1a, 0x40, 0x20)
+
+
+
+    // fill up the stack for stack operations below
+    pc 0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45 caller 0x00 
+    gas 0x48bed44d1bcd124a28c27f343a817e5f5243190d3c52bf347daf876de1dbbf77 address 0x01                     
+    pc 0x4e03657aea45a94fc7d47ba826c8d667c0d1e6e33a64a036ec44f58fa12d6c45 caller 0x00 
+    gas 0x48bed44d1bcd124a28c27f343a817e5f5243190d3c52bf347daf876de1dbbf77 address 0x01                     // [0x01, address(this), randomHash, gas, 0x00, caller, randomHash, pc, 0x01, address(this), randomHash, gas, 0x00, caller, randomHash, pc]]
+
+              
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b2031) 0x00 mstore
+    [RED] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0b, 0x40, 0x20)
+
+    LOG_STACK_1(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b2032) 0x00 mstore
+    [GREEN] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0b, 0x40, 0x20)
+
+    LOG_STACK_2(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b2033) 0x00 mstore
+    [YELLOW] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0b, 0x40, 0x20)
+
+    LOG_STACK_3(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b2034) 0x00 mstore
+    [BLUE] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0b, 0x40, 0x20)
+
+    LOG_STACK_4(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b2035) 0x00 mstore
+    [MAGENTA] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0b, 0x40, 0x20)
+
+    LOG_STACK_5(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b2036) 0x00 mstore
+    [BOLD] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0b, 0x40, 0x20)
+
+    LOG_STACK_6(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b2037) 0x00 mstore
+    [DIM] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0b, 0x40, 0x20)
+
+    LOG_STACK_7(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b2038) 0x00 mstore
+    [ITALIC] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0b, 0x40, 0x20)
+
+    LOG_STACK_8(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b2039) 0x00 mstore
+    [UNDERLINE] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0b, 0x40, 0x20)
+
+    LOG_STACK_9(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b203130) 0x00 mstore
+    [INVERSE] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0c, 0x40, 0x20)
+
+    LOG_STACK_10(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b203131) 0x00 mstore
+    [RED] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0c, 0x40, 0x20)
+
+    LOG_STACK_11(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b203132) 0x00 mstore
+    [GREEN] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0c, 0x40, 0x20)
+
+    LOG_STACK_12(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b203133) 0x00 mstore
+    [YELLOW] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0c, 0x40, 0x20)
+
+    LOG_STACK_13(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b203134) 0x00 mstore
+    [BLUE] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0c, 0x40, 0x20)
+
+    LOG_STACK_14(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b203135) 0x00 mstore
+    [MAGENTA] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0c, 0x40, 0x20)
+
+    LOG_STACK_15(0x00)
+
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b203136) 0x00 mstore
+    [CYAN] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0c, 0x40, 0x20)
+
+    LOG_STACK_16(0x00)
+
+    
+
+    LINE_BREAK(0x00, 0x20)
+
+    __RIGHTPAD(0x4c4f4720535441434b205459504553) 0x00 mstore
+    [BOLD] 0x20 mstore
+    LOG_MEMORY_AS_STRING_STYLE(0x00, 0x0f, 0x40, 0x20)
+
+    // logs stack item 1 as a boolean
+    LOG_STACK_AS_BOOL(dup1, 0x00)               // [0x01, address(this), blockhash, gas, 0x00, caller, gasprice, pc]
+
+    // logs stack item 2 as an address
+    LOG_STACK_AS_ADDRESS(dup2, 0x00)            // [0x01, address(this), blockhash, gas, 0x00, caller, gasprice, pc]
+
+    // log stack item 3 as a bytes32
+    LOG_STACK_AS_BYTES32(dup3, 0x00)            // [0x01, address(this), blockhash, gas, 0x00, caller, gasprice, pc]
+
+    // log stack item 4 as a uint256
+    LOG_STACK_AS_UINT(dup4, 0x00)               // [0x01, address(this), blockhash, gas, 0x00, caller, gasprice, pc]
+
+    // logs stack item 5 as a boolean
+    LOG_STACK_AS_BOOL(dup5, 0x00)               // [0x01, address(this), blockhash, gas, 0x00, caller, gasprice, pc]
+
+    // log stack item 6 as an address
+    LOG_STACK_AS_ADDRESS(dup6, 0x00)            // [0x01, address(this), blockhash, gas, 0x00, caller, gasprice, pc]
+
+    // log stack item 7 as a bytes32
+    LOG_STACK_AS_BYTES32(dup7, 0x00)            // [0x01, address(this), blockhash, gas, 0x00, caller, gasprice, pc]
+
+    // log stack item 8 as a uint256
+    LOG_STACK_AS_UINT(dup8, 0x00)               // [0x01, address(this), blockhash, gas, 0x00, caller, gasprice, pc]
+
+    0x00 0x00 return
+}
+


### PR DESCRIPTION
# Console.log functionalities for Huff contracts

[Console.huff]("https://github.com/AmadiMichael/Huff-Console/blob/main/src/Console.huff") lets devs visualize the state of the stack, memory and calldata at any point while huffing simply by specifying what they wish to visualize all using foundry's native console logging functionality under the hood.

Huffors can

- log out the stack (up to 16 items deep) as bytes32 values (similar to evm.codes)
- log individual stack items as any variable type (uint256, int256, address, bool, bytes32)
- log out an area of memory or calldata as bytes(dynamic) or as a string.

- (experimental): log out an area in memory as a string and with styling (using foundry's new log styling feature)

`src/test/contracts/HuffConsoleWrapper.huff` has examples on how it can be used. 

Run `forge test -vvv` to see how it displays.