### PR TITLE
🐛 fix path for windows

### DIFF
--- a/remappings.txt
+++ b/remappings.txt
@@ -1,2 +1,2 @@
 forge-std/=lib/forge-std/src/
-stringutils/=lib/solidity-stringutils/
+stringutils/=lib/solidity-stringutils/src/


### PR DESCRIPTION
This fixes the issue when you `forge build` in Windows and get `error[7858]`

```
Compiler run failed
error[7858]: ParserError: Expected pragma, import directive or contract/interface/library/struct/enum/constant/function/error definition.
 --> lib/foundry-huff/lib/solidity-stringutils/strings.sol:1:1:
  |
1 | ./src/strings.sol
  | ^
```
