### PR TITLE
feat: add ability to set evm version

### DIFF
--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -187,15 +187,15 @@ contract HuffConfig {
         vm.ffi(append_cmds);
 
         /// Create a list of strings with the commands necessary to compile Huff contracts
-        string[] memory cmds = new string[](3);
+        string[] memory cmds = new string[](5);
         if (const_overrides.length > 0) {
-            cmds = new string[](4 + const_overrides.length);
-            cmds[3] = "-c";
+            cmds = new string[](6 + const_overrides.length);
+            cmds[5] = "-c";
 
             Constant memory cur_const;
             for (uint256 i; i < const_overrides.length; i++) {
                 cur_const = const_overrides[i];
-                cmds[4 + i] = string.concat(cur_const.key, "=", cur_const.value);
+                cmds[6 + i] = string.concat(cur_const.key, "=", cur_const.value);
             }
         }
 

--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -32,6 +32,9 @@ contract HuffConfig {
     /// @notice whether to broadcast the deployment tx
     bool public should_broadcast;
 
+    /// @notice supported evm versions
+    string public evm_version;
+
     /// @notice constant overrides for the current compilation environment
     Constant[] public const_overrides;
 
@@ -56,6 +59,12 @@ contract HuffConfig {
     /// @notice sets the caller of the next deployment
     function with_deployer(address _deployer) public returns (HuffConfig) {
         deployer = _deployer;
+        return this;
+    }
+
+    /// @notice sets the evm version to compile with
+    function with_evm_version(string memory _evm_version) public returns (HuffConfig) {
+        evm_version = _evm_version;
         return this;
     }
 
@@ -124,6 +133,15 @@ contract HuffConfig {
         return string(str);
     }
 
+    /// @notice Get the evm version string | else return default ("shanghai")
+    function get_evm_version() public view returns (string memory) {
+        bytes32 _evm_version = bytes32(bytes(abi.encodePacked(evm_version)));
+        if (_evm_version == bytes32(0x0)) {
+            return "shanghai";
+        }
+        return evm_version;
+    }
+
     /// @notice Get the creation bytecode of a contract
     function creation_code(string memory file) public payable returns (bytes memory bytecode) {
         binary_check();
@@ -184,6 +202,8 @@ contract HuffConfig {
         cmds[0] = "huffc";
         cmds[1] = string(string.concat("src/", tempFile, ".huff"));
         cmds[2] = "-b";
+        cmds[3] = "-e";
+        cmds[4] = get_evm_version();
 
         /// @notice compile the Huff contract and return the bytecode
         bytecode = vm.ffi(cmds);

--- a/src/test/HuffConfig.t.sol
+++ b/src/test/HuffConfig.t.sol
@@ -47,4 +47,9 @@ contract HuffConfigTest is Test {
         bool b = config.should_broadcast();
         assertEq(b, broadcast);
     }
+
+    function testWithEvmVersion() public {
+        config.with_evm_version("paris");
+        assertEq(config.evm_version(), "paris");
+    }
 }

--- a/src/test/contracts/EVMVersionCheck.huff
+++ b/src/test/contracts/EVMVersionCheck.huff
@@ -1,0 +1,5 @@
+
+
+#define macro MAIN() = {
+    0x00
+}


### PR DESCRIPTION
Allow developers to pick which evm version they deploy to. 

depends on: https://github.com/huff-language/huff-rs/pull/281