### PR TITLE
Require length of bytecode > 0

### DIFF
--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -187,6 +187,7 @@ contract HuffConfig {
 
         /// @notice compile the Huff contract and return the bytecode
         bytecode = vm.ffi(cmds);
+        require(bytecode.length > 0, "Failed to compile Huff contract.");
 
         // Clean up temp files
         string[] memory cleanup = new string[](2);


### PR DESCRIPTION
The Huff deployer deploys a contract even if no Huff file exists (bytecode.length == 0). 

We can solve this by checking the length of bytecode. If it is zero, the deployment reverts. 