### PR TITLE
Fix Active Prank Issue Causing Deploy Crash During Broadcast

### DIFF
--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -232,7 +232,11 @@ contract HuffConfig {
 
         /// @notice deploy the bytecode with the create instruction
         address deployedAddress;
-        if (should_broadcast) vm.broadcast();
+        if (should_broadcast) {
+            // @notice stop current prank in order to broadcast to the network
+            vm.stopPrank();
+            vm.broadcast();
+        }
         assembly {
             let val := sload(value.slot)
             deployedAddress := create(val, add(concatenated, 0x20), mload(concatenated))


### PR DESCRIPTION
There is a bug within the existing implementation of the `deploy` function in `HuffConfig.sol.` Specifically, if a user intends to broadcast the deployment of the huff contract to a network, the ongoing active prank in the `creation_code_with_args` function disrupts the transaction flow, leading to a transaction failure. Consequently, this renders the deployment of huff contracts across any network utilising this framework unfeasible. The resultant console output below underscores this situation:

```
Error: 
You have an active prank. Broadcasting and pranks are not compatible. Disable one or the other

```
To address this predicament, I've incorporated the vm.stopPrank() invocation just prior to the commencement of the broadcast. This strategic inclusion effectively resolves the bug:

```
Script ran successfully.
```