### PR TITLE
Silence binary check errors

### DIFF
--- a/scripts/binary_check.sh
+++ b/scripts/binary_check.sh
@@ -1,9 +1,9 @@
 #! /bin/bash
 
-if ! [[ "$(npm list -g huffc)" =~ "empty" ]]; then
+if ! [[ "$(npm list -g huffc 2> /dev/null)" =~ "empty" ]]; then
   # huffc was installed via npm, return 0x00
   echo -n 0x00
-elif [[ "$(yarn global list)" =~ "huffc" ]]; then
+elif [[ "$(yarn global list 2> /dev/null)" =~ "huffc" ]]; then
   # huffc was installed via yarn, return 0x00
   echo -n 0x00
 else


### PR DESCRIPTION
This PR prevents unneeded error log which occurs when `npm` or `yarn` executables are missing (or misconfigured) in the system. 

Before: 
<img width="1147" alt="Screenshot 2023-11-25 at 21 42 18" src="https://github.com/huff-language/foundry-huff/assets/1131944/29eb8aae-9da2-4a60-95ef-e6aca70fc8ac">

After: 
<img width="1147" alt="Screenshot 2023-11-25 at 21 42 57" src="https://github.com/huff-language/foundry-huff/assets/1131944/0add4ed2-184c-40c9-9867-7ac6d638b52e">
