### PR TITLE
Fix Path - StringUtils - Update HuffConfig.sol

### DIFF
--- a/src/HuffConfig.sol
+++ b/src/HuffConfig.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.13 <0.9.0;
 
 import {Vm} from "forge-std/Vm.sol";
-import {strings} from "stringutils/strings.sol";
+import {strings} from "stringutils/src/strings.sol";
 
 contract HuffConfig {
     using strings for *;


### PR DESCRIPTION
Fixed path to reference correct strings.sol -- this err was causing issues for me compiling my tests, noticed that we are not referencing the correct strings.sol contract from HuffConfig.sol in stringutils
![Screenshot 2024-01-12 061805](https://github.com/huff-language/foundry-huff/assets/156262846/6bdd71d3-6ee1-4fd7-82aa-500a609cb20b)
After changes:
![Screenshot 2024-01-12 061839](https://github.com/huff-language/foundry-huff/assets/156262846/5dad670b-6511-4aaf-82e4-b47bd84754fc)

