### PR TITLE
updated script for people who dont have npm or yarn installed

### DIFF
--- a/scripts/binary_check.sh
+++ b/scripts/binary_check.sh
@@ -2,7 +2,7 @@
 
 # Check if npm is installed
 if command -v npm &> /dev/null; then
-  if ! [[ "$(npm list -g huffc)" =~ "empty" ]]; then
+  if ! [[ "$(npm list -g huffc 2> /dev/null)" =~ "empty" ]]; then
     # huffc was installed via npm, return 0x00
     echo -n 0x00
     exit 0
@@ -11,7 +11,7 @@ fi
 
 # Check if yarn is installed
 if command -v yarn &> /dev/null; then
-  if [[ "$(yarn global list)" =~ "huffc" ]]; then
+  if [[ "$(yarn global list 2> /dev/null)" =~ "huffc" ]]; then
     # huffc was installed via yarn, return 0x00
     echo -n 0x00
     exit 0

--- a/scripts/binary_check.sh
+++ b/scripts/binary_check.sh
@@ -1,11 +1,22 @@
 #! /bin/bash
 
-if ! [[ "$(npm list -g huffc)" =~ "empty" ]]; then
-  # huffc was installed via npm, return 0x00
-  echo -n 0x00
-elif [[ "$(yarn global list)" =~ "huffc" ]]; then
-  # huffc was installed via yarn, return 0x00
-  echo -n 0x00
-else
-  echo -n 0x01
+# Check if npm is installed
+if command -v npm &> /dev/null; then
+  if ! [[ "$(npm list -g huffc)" =~ "empty" ]]; then
+    # huffc was installed via npm, return 0x00
+    echo -n 0x00
+    exit 0
+  fi 
 fi
+
+# Check if yarn is installed
+if command -v yarn &> /dev/null; then
+  if [[ "$(yarn global list)" =~ "huffc" ]]; then
+    # huffc was installed via yarn, return 0x00
+    echo -n 0x00
+    exit 0
+  fi 
+fi
+
+# Else, return 0x01
+echo -n 0x01


### PR DESCRIPTION
A friend of mine following our new Assembly and Formal Verification course on [Cyfrin Updraft](https://updraft.cyfrin.io/) were running into an error where the `binary_check.sh` script errors if the user doesn't have npm or yarn installed. 

So we updated the script to check for those first, otherwise, huff will always fail.

