### PR TITLE
use more portable script interpreter shebang

### DIFF
--- a/lib/foundry-huff/scripts/binary_check.sh
+++ b/lib/foundry-huff/scripts/binary_check.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 if ! [[ "$(npm list -g huffc)" =~ "empty" ]]; then
   # huffc was installed via npm, return 0x00

--- a/lib/foundry-huff/scripts/file_writer.sh
+++ b/lib/foundry-huff/scripts/file_writer.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 echo "$2" > $1

--- a/lib/foundry-huff/scripts/rand_bytes.sh
+++ b/lib/foundry-huff/scripts/rand_bytes.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 echo -n $(hexdump -n 16 -v -e '"0x" 32/1 "%02x" "\n"' /dev/urandom)

--- a/lib/foundry-huff/scripts/read_and_append.sh
+++ b/lib/foundry-huff/scripts/read_and_append.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 cat $2 >> $1

--- a/scripts/binary_check.sh
+++ b/scripts/binary_check.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 # Check if npm is installed
 if command -v npm &> /dev/null; then

--- a/scripts/file_writer.sh
+++ b/scripts/file_writer.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 echo "$2" > $1

--- a/scripts/rand_bytes.sh
+++ b/scripts/rand_bytes.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 echo -n $(hexdump -n 16 -v -e '"0x" 32/1 "%02x" "\n"' /dev/urandom)

--- a/scripts/read_and_append.sh
+++ b/scripts/read_and_append.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 cat $2 >> $1


### PR DESCRIPTION
Bash doesn't always exist at `/bin/bash` on some distros like NixOS.

If no bash-specific features are required, the interpreter could even potentially be replaced by `/bin/sh`.